### PR TITLE
Skip POSIX-specific tests on Windows

### DIFF
--- a/tests/test_ctrlc.py
+++ b/tests/test_ctrlc.py
@@ -9,6 +9,7 @@ import signal
 from aiotk import handle_ctrlc
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_ctrlc(event_loop):
     done = asyncio.Future()
@@ -18,6 +19,7 @@ async def test_ctrlc(event_loop):
     assert done.result() is None
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_ctrlc_idempotent(event_loop):
     done = asyncio.Future()

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -7,6 +7,7 @@ import pytest
 from aiotk.posix import UnixSocketServer
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server(event_loop, tempcwd):
     """Basic connectivity check."""
@@ -36,6 +37,7 @@ async def test_unix_server(event_loop, tempcwd):
             writer.close()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_start_while_starting(event_loop, tempcwd):
     """Cannot call start while server is starting."""
@@ -55,6 +57,7 @@ async def test_unix_server_start_while_starting(event_loop, tempcwd):
         await server.wait_closed()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_start_while_running(event_loop, tempcwd):
     """Cannot call start while server is running."""
@@ -74,6 +77,7 @@ async def test_unix_server_start_while_running(event_loop, tempcwd):
         await server.wait_closed()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_wait_started_while_stopped(event_loop, tempcwd):
     """Cannot call wait_started while server is stopped."""
@@ -87,6 +91,7 @@ async def test_unix_server_wait_started_while_stopped(event_loop, tempcwd):
         await server.wait_started()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_wait_started_idempotent(event_loop, tempcwd):
     """Can call wait_started as much as you want."""
@@ -107,6 +112,7 @@ async def test_unix_server_wait_started_idempotent(event_loop, tempcwd):
         await server.wait_closed()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_wait_closed_idempotent(event_loop, tempcwd):
     """Can call wait_closed as much as you want."""
@@ -132,6 +138,7 @@ async def test_unix_server_wait_closed_idempotent(event_loop, tempcwd):
     await server.wait_closed()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_close_idempotent(event_loop, tempcwd):
     """Can call wait_closed as much as you want."""
@@ -161,6 +168,7 @@ async def test_unix_server_close_idempotent(event_loop, tempcwd):
     server.close()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_close_while_starting(event_loop, tempcwd):
     """Cannot call close while starting."""
@@ -181,6 +189,7 @@ async def test_unix_server_close_while_starting(event_loop, tempcwd):
         await server.wait_closed()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_wait_closed_timeout(event_loop, tempcwd):
     """Not finished closing until all sessions complete."""
@@ -226,6 +235,7 @@ async def test_unix_server_wait_closed_timeout(event_loop, tempcwd):
         await server.wait_closed()
 
 
+@pytest.mark.skipif('sys.platform == "win32"')
 @pytest.mark.asyncio
 async def test_unix_server_auto_close_connection(event_loop, tempcwd):
     """Connections are closed automatically when sessions finish."""


### PR DESCRIPTION
This allows verifying that all platform-agnostic functionality works on
Windows.