### PR TITLE
Enable binding TCP server to randomly selected available port

### DIFF
--- a/src/aiotk/tcp.py
+++ b/src/aiotk/tcp.py
@@ -50,7 +50,11 @@ class TCPServer(object):
       application (includes handling of a rare race condition)
 
     :param host: Network interface on which to listen for incoming connections.
-    :param port: Port number on which to listen for incoming connections.
+
+    :param port: Port number on which to listen for incoming connections.  You
+     can pass a value of zero to ask the system to pick an available port for
+     you.  After ``wait_started()``, the ``port`` property will contain the
+     port number on which the server is listening.
     :param callback: Coroutine function that will be used to spawn a task for
      each established connection.  This coroutine must accept two positional
      arguments: ``(reader, writer)`` which allow interaction with the peer.
@@ -86,6 +90,12 @@ class TCPServer(object):
         See:
 
         - :py:data:`aiotk.TCPServer.host`
+
+        .. versionchanged:: 0.4.1
+
+           When asking the system to choose the available port, this property
+           now returns the actual port number (rather than zero).
+
         """
         return self._port
 
@@ -128,6 +138,7 @@ class TCPServer(object):
             raise Exception('Not started.')
         if isinstance(self._server, asyncio.Future):
             self._server = await self._server
+            self._port = self._server.sockets[0].getsockname()[1]
 
     # NOTE: cancel pending sessions immediately.
     #

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -62,11 +62,10 @@ async def test_tcp_server_fn(event_loop, unused_tcp_port):
 
 
 @pytest.mark.asyncio
-async def test_tcp_server(event_loop, unused_tcp_port):
+async def test_tcp_server(event_loop):
     """Basic connectivity check."""
 
     host = '127.0.0.1'
-    port = unused_tcp_port
 
     async def echo(reader, writer):
         try:
@@ -77,12 +76,12 @@ async def test_tcp_server(event_loop, unused_tcp_port):
         finally:
             writer.close()
 
-    async with TCPServer(host, port, echo, event_loop) as server:
+    async with TCPServer(host, 0, echo, event_loop) as server:
         assert server.host == host
-        assert server.port == port
+        assert server.port > 0
         reader, writer = await asyncio.open_connection(
             host=host,
-            port=port,
+            port=server.port,
             loop=event_loop,
         )
         try:


### PR DESCRIPTION
We can trivially ask the operating system to pick an available port for us by
binding to port zero.  However, we then need to recover the port number to
publish it to clients and that was not previously possible because the
`TCPServer.port` property always returned zero.