### PR TITLE
Update docs dependencies

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,8 @@ Purpose
 =======
 
 This is a collection of asyncio-related utilities that I have found useful,
-that I've used in at least two projects and that seem like they might be useful
-to others.
+that I have used in at least two projects and that seem like they might be
+useful to others.
 
 
 Contents:

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,5 +1,5 @@
 doc8==0.7.0
-pyenchant==1.6.7
-releases==1.2.1
-Sphinx==1.4.5
-sphinxcontrib-spelling==2.2.0
+pyenchant==2.0.0
+releases==1.5.0
+Sphinx==1.6.7
+sphinxcontrib-spelling==4.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,21 +1,25 @@
 alabaster==0.7.10         # via sphinx
 babel==2.5.1              # via sphinx
-chardet==3.0.4            # via doc8
-colorama==0.3.9           # via sphinx
+certifi==2018.4.16        # via requests
+chardet==3.0.4            # via doc8, requests
 doc8==0.7.0
 docutils==0.14            # via doc8, restructuredtext-lint, sphinx
+idna==2.6                 # via requests
 imagesize==0.7.1          # via sphinx
 jinja2==2.9.6             # via sphinx
 markupsafe==1.0           # via jinja2
 pbr==3.1.1                # via stevedore
-pyenchant==1.6.7
+pyenchant==2.0.0
 pygments==2.2.0           # via sphinx
 pytz==2017.2              # via babel
-releases==1.2.1
+releases==1.5.0
+requests==2.18.4          # via sphinx
 restructuredtext-lint==1.1.1  # via doc8
 semantic-version==2.6.0   # via releases
 six==1.11.0               # via doc8, sphinx, sphinxcontrib-spelling, stevedore
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.4.5
-sphinxcontrib-spelling==2.2.0
+sphinx==1.6.7
+sphinxcontrib-spelling==4.1.0
+sphinxcontrib-websupport==1.0.1  # via sphinx
 stevedore==1.27.0         # via doc8
+urllib3==1.22             # via requests

--- a/src/aiotk/__init__.py
+++ b/src/aiotk/__init__.py
@@ -25,7 +25,7 @@ from ._sched import PeriodicTask
 def run_until_complete(coro, loop=None):
     """Run a task through to completion.
 
-    The ``.run_until_complete()`` method on asyncio event loop objects doesn't
+    The ``.run_until_complete()`` method on asyncio event loop objects does not
     finish tasks when it receives a SIGINT/CTRL-C.  The method simply raises a
     ``KeyboardInterrupt`` exception and this usually results in warnings about
     unfinished tasks plus some "event loop closed" ``RuntimeError`` exceptions


### PR DESCRIPTION
While trying out `mypy`, I needed to update the documentation
dependencies to handle type annotations on documented functions.

Here is an isolated change of the documentation updates to keep
the `mypy` diff as small as possible.