### PR TITLE
Prevent concurrent deploys on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,4 @@ deploy:
       zLiQA7kQQ69CyjvTSbDPZ3iMy178XmNOzBPrsJV5aRCyumSjKl8TNHM53hTVNM=
   on:
     tags: true
+    condition: $TOXENV = py35


### PR DESCRIPTION
Last deploy ended up with 2 concurrent jobs (from our build matrix)
trying to upload to PyPI at the same time.  This change ensures that
only one of the changes (the one that runs the tests) will result
in deployment.

See: https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A